### PR TITLE
Add pre-commit hook definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: licensesnip
+  name: check license headers in files
+  description: check license headers in files
+  entry: licensesnip
+  language: rust
+  args: ["check"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ licensesnip src/main.rs
 licensesnip remove src/
 ```
 
+### Pre-commit hook
+
+You can use `licensesnip` with [pre-commit](https://pre-commit.com). Add it to your local `.pre-commit-config.yaml` as follows:
+
+```yaml
+- repo: https://github.com/notken12/licensesnip
+  rev: v1.1.3 # choose your preferred tag
+  hooks:
+    - id: licensesnip
+    - args: ["check"] # optionally modify the arguments for licensesnip (default arguments shown here)
+```
+
 ## ⚙️ Configuration
 
 Find your global Licensesnip config file:


### PR DESCRIPTION
This allows using licensesnip as a pre-commit hook out of the box. See https://pre-commit.com/#new-hooks for information about creating pre-commit hooks.

Example repository that already defines a pre-commit configuration: https://github.com/DevinR528/cargo-sort