### PR TITLE
Support multiple file arguments to check subcommand

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -68,7 +68,7 @@ pub enum Commands {
     #[clap(arg_required_else_help = false)]
     Check {
         /// The file(s) to check
-        file: Option<PathBuf>,
+        files: Vec<PathBuf>,
         /// Display more information
         #[clap(short, long)]
         verbose: bool,

--- a/src/license.rs
+++ b/src/license.rs
@@ -108,6 +108,7 @@ pub enum ReadLicenseErr {
     FileReadErr,
 }
 
+#[derive(Clone)]
 pub struct License {
     pub raw_text: String,
 }


### PR DESCRIPTION
This helps licensesnip play nicely with pre-commit, which passes every file in the commit in one go to the hook.